### PR TITLE
Patch: Handle case where there's no current localStorage

### DIFF
--- a/packages/react-app/src/components/IpfsUploader.jsx
+++ b/packages/react-app/src/components/IpfsUploader.jsx
@@ -36,8 +36,10 @@ export default class IpfsUploader extends Component {
     // Restores the user's upload history from local storage
     loadState() {
         let json = localStorage.getItem("upload_history");
-        let localHistory = JSON.parse(json);
-        this.setState({history: localHistory});
+        if (json != null) {
+            let localHistory = JSON.parse(json);
+            this.setState({history: localHistory});
+        }
     }
 
     // Add an uploaded image to the history


### PR DESCRIPTION
In the last change, I didn't handle the case where local storage was empty 

Fixes the issue in #2 after the last change.